### PR TITLE
fix: race condition in wgengine

### DIFF
--- a/wgengine/userspace.go
+++ b/wgengine/userspace.go
@@ -1005,6 +1005,7 @@ func (e *userspaceEngine) getStatus() (*Status, error) {
 	closing := e.closing
 	peerKeys := make([]key.NodePublic, len(e.peerSequence))
 	copy(peerKeys, e.peerSequence)
+	localAddrs := append([]tailcfg.Endpoint(nil), e.endpoints...)
 	e.mu.Unlock()
 
 	if closing {
@@ -1020,7 +1021,7 @@ func (e *userspaceEngine) getStatus() (*Status, error) {
 
 	return &Status{
 		AsOf:       time.Now(),
-		LocalAddrs: append([]tailcfg.Endpoint(nil), e.endpoints...),
+		LocalAddrs: localAddrs,
 		Peers:      peers,
 		DERPs:      derpConns,
 	}, nil


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c0001a5618 by goroutine 32960:
  tailscale.com/wgengine.NewUserspaceEngine.func2()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/userspace.go:345 +0xc6
  tailscale.com/wgengine/magicsock.(*Conn).updateEndpoints()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/magicsock/magicsock.go:656 +0x45e
  tailscale.com/wgengine/magicsock.(*Conn).ReSTUN.func2()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/magicsock/magicsock.go:2786 +0x58
Previous read at 0x00c0001a5618 by goroutine 33297:
  tailscale.com/wgengine.(*userspaceEngine).getStatus()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/userspace.go:1023 +0x224
  tailscale.com/wgengine.(*userspaceEngine).UpdateStatus()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/userspace.go:1193 +0x51
  tailscale.com/wgengine.(*watchdogEngine).UpdateStatus.func1()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/watchdog.go:143 +0x55
  tailscale.com/wgengine.(*watchdogEngine).watchdog.func1()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/watchdog.go:122 +0x30
  tailscale.com/wgengine.(*watchdogEngine).watchdogErr.func2()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/watchdog.go:88 +0x39
Goroutine 32960 (running) created at:
  tailscale.com/wgengine/magicsock.(*Conn).ReSTUN()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/magicsock/magicsock.go:2786 +0x5ce
  tailscale.com/wgengine/magicsock.(*Conn).SetPrivateKey.func3()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/magicsock/magicsock.go:2202 +0x45
Goroutine 33297 (running) created at:
  tailscale.com/wgengine.(*watchdogEngine).watchdogErr()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/watchdog.go:87 +0x35b
  tailscale.com/wgengine.(*watchdogEngine).watchdog()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/watchdog.go:121 +0xaf
  tailscale.com/wgengine.(*watchdogEngine).UpdateStatus()
      /home/runner/go/pkg/mod/github.com/coder/tailscale@v1.1.1-0.20220907193453-fb5ba5ab658d/wgengine/watchdog.go:143 +0xe7
  github.com/coder/coder/tailnet.(*Conn).Status()
      /home/runner/work/coder/coder/tailnet/conn.go:366 +0xbe
  github.com/coder/coder/tailnet.(*Conn).UpdateNodes()
      /home/runner/work/coder/coder/tailnet/conn.go:311 +0x13b
  github.com/coder/coder/coderd_test.TestDERP.func2()
      /home/runner/work/coder/coder/coderd/coderd_test.go:94 +0x55
  github.com/coder/coder/tailnet.(*Conn).SetNodeCallback.func2()
      /home/runner/work/coder/coder/tailnet/conn.go:271 +0x8b
==================
```
