### PR TITLE
net/connstats: always stat even if no activity occurred

### DIFF
--- a/net/connstats/stats.go
+++ b/net/connstats/stats.go
@@ -67,7 +67,7 @@ func NewStatistics(maxPeriod time.Duration, maxConns int, dump func(start, end t
 			case <-s.shutdownCtx.Done():
 				cc = s.extract()
 			}
-			if len(cc.virtual)+len(cc.physical) > 0 && dump != nil {
+			if dump != nil {
 				dump(cc.start, cc.end, cc.virtual, cc.physical)
 			}
 			if s.shutdownCtx.Err() != nil {


### PR DESCRIPTION
It should be on the responsibility of the caller to send stats or not if no activity occurred. This was making it difficult to periodically send stats because we'd need multiple tickers that would have to align.