### PR TITLE
derp/derphttp: wait for websocket connections to exit on close

### DIFF
--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -348,7 +348,7 @@ func (c *Client) connect(ctx context.Context, caller string) (client *derp.Clien
 		}
 		c.serverPubKey = derpClient.ServerPublicKey()
 		c.client = derpClient
-		c.netConn = tcpConn
+		c.netConn = conn
 		c.connGen++
 		return c.client, c.connGen, nil
 	case c.url != nil:


### PR DESCRIPTION
This was causing a leak in our CI!

This should definitely be upstreamed... it's a bug in Tailscale! https://github.com/tailscale/tailscale/pull/7483