### PR TITLE
net/netcheck: remove custom captive portal check removal

### DIFF
--- a/derp/derphttp/websocket.go
+++ b/derp/derphttp/websocket.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 //go:build !js
 
 package derphttp

--- a/net/netcheck/netcheck.go
+++ b/net/netcheck/netcheck.go
@@ -960,10 +960,6 @@ func (c *Client) GetReport(ctx context.Context, dm *tailcfg.DERPMap) (_ *Report,
 		}
 	}
 
-	// Never perform the captive portal check. We don't use
-	// this in Coder, so it just adds time to the initial connect.
-	captivePortalStop()
-
 	wg := syncs.NewWaitGroupChan()
 	wg.Add(len(plan))
 	for _, probeSet := range plan {


### PR DESCRIPTION
This was causing tests to fail, which makes me suspicious of if it's actually doing what the comment says...