### PR TITLE
derp/derphttp: pass the headers to the websocket dial

### DIFF
--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -247,7 +247,7 @@ func (c *Client) preferIPv6() bool {
 }
 
 // dialWebsocketFunc is non-nil (set by websocket.go's init) when compiled in.
-var dialWebsocketFunc func(ctx context.Context, urlStr string, tlsConfig *tls.Config) (net.Conn, error)
+var dialWebsocketFunc func(ctx context.Context, urlStr string, tlsConfig *tls.Config, httpHeader http.Header) (net.Conn, error)
 
 func (c *Client) useWebsockets() bool {
 	if runtime.GOOS == "js" {
@@ -326,7 +326,7 @@ func (c *Client) connect(ctx context.Context, caller string) (client *derp.Clien
 			tlsConfig = c.tlsConfig(reg.Nodes[0])
 		}
 		c.logf("%s: connecting websocket to %v", caller, urlStr)
-		conn, err := dialWebsocketFunc(ctx, urlStr, tlsConfig)
+		conn, err := dialWebsocketFunc(ctx, urlStr, tlsConfig, c.Header)
 		if err != nil {
 			c.logf("%s: websocket to %v error: %v", caller, urlStr, err)
 			return nil, 0, err

--- a/derp/derphttp/websocket.go
+++ b/derp/derphttp/websocket.go
@@ -17,9 +17,10 @@ func init() {
 	dialWebsocketFunc = dialWebsocket
 }
 
-func dialWebsocket(ctx context.Context, urlStr string, tlsConfig *tls.Config) (net.Conn, error) {
+func dialWebsocket(ctx context.Context, urlStr string, tlsConfig *tls.Config, httpHeader http.Header) (net.Conn, error) {
 	c, res, err := websocket.Dial(ctx, urlStr, &websocket.DialOptions{
 		Subprotocols: []string{"derp"},
+		HTTPHeader:   httpHeader,
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: tlsConfig,

--- a/derp/derphttp/websocket_js.go
+++ b/derp/derphttp/websocket_js.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"log"
 	"net"
+	"net/http"
 
 	"nhooyr.io/websocket"
 	"tailscale.com/net/wsconn"
@@ -19,9 +20,8 @@ func init() {
 	dialWebsocketFunc = dialWebsocket
 }
 
-func dialWebsocket(ctx context.Context, urlStr string, _ *tls.Config, httpHeader http.Header) (net.Conn, error) {
+func dialWebsocket(ctx context.Context, urlStr string, _ *tls.Config, _ http.Header) (net.Conn, error) {
 	c, res, err := websocket.Dial(ctx, urlStr, &websocket.DialOptions{
-		HTTPHeader:   httpHeader,
 		Subprotocols: []string{"derp"},
 	})
 	if err != nil {

--- a/derp/derphttp/websocket_js.go
+++ b/derp/derphttp/websocket_js.go
@@ -19,8 +19,9 @@ func init() {
 	dialWebsocketFunc = dialWebsocket
 }
 
-func dialWebsocket(ctx context.Context, urlStr string, _ *tls.Config) (net.Conn, error) {
+func dialWebsocket(ctx context.Context, urlStr string, _ *tls.Config, httpHeader http.Header) (net.Conn, error) {
 	c, res, err := websocket.Dial(ctx, urlStr, &websocket.DialOptions{
+		HTTPHeader: httpHeader
 		Subprotocols: []string{"derp"},
 	})
 	if err != nil {

--- a/derp/derphttp/websocket_js.go
+++ b/derp/derphttp/websocket_js.go
@@ -21,7 +21,7 @@ func init() {
 
 func dialWebsocket(ctx context.Context, urlStr string, _ *tls.Config, httpHeader http.Header) (net.Conn, error) {
 	c, res, err := websocket.Dial(ctx, urlStr, &websocket.DialOptions{
-		HTTPHeader: httpHeader
+		HTTPHeader:   httpHeader,
 		Subprotocols: []string{"derp"},
 	})
 	if err != nil {


### PR DESCRIPTION
This PR modifies the `dialWebsocketFunc` to allow any DERP HTTP headers to be also passed through when dialing the websocket.

This expands upon the changes introduced in https://github.com/coder/tailscale/pull/6 to avoid errors like the one below:
```
2023-03-12 06:11:38.503 [DEBUG]	(wgengine)	<./../../../tailscale.com/derp/derphttp/derphttp_client.go:328>	(*Client).connect	derphttp.Client.Recv: connecting websocket to https://coder.some-reverse-proxy.com/derp
2023/03/12 17:11:38 websocket Dial: failed to WebSocket dial: expected handshake response status code 101 but got 403, &{Status:403 Forbidden StatusCode:403 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Cf-Ray:[7a69e1879b37ab01-SYD] Connection:[keep-alive] Content-Length:[151] Content-Type:[text/html] Date:[Sun, 12 Mar 2023 06:11:38 GMT] Server:[cloudflare]] Body:{Reader:0x140019b6330} ContentLength:151 TransferEncoding:[] Close:false Uncompressed:false Trailer:map[] Request:0x140012edf00 TLS:0x1400164a4d0}
2023-03-12 06:11:38.832 [DEBUG]	(wgengine)	<./../../../tailscale.com/derp/derphttp/derphttp_client.go:331>	(*Client).connect	derphttp.Client.Recv: websocket to https://coder.some-reverse-proxy.com/derp error: failed to WebSocket dial: expected handshake response status code 101 but got 403
2023-03-12 06:11:38.832 [DEBUG]	(wgengine)	<./../../../tailscale.com/wgengine/magicsock/magicsock.go:1671>	(*Conn).runDerpReader	magicsock: [0x14000928200] derp.Recv(derp-999): derphttp.Client.Recv connect to region 999 (coder): failed to WebSocket dial: expected handshake response status code 101 but got 403
```