### PR TITLE
fix: add websocket fallback when http2 is used

### DIFF
--- a/derp/derphttp/websocket.go
+++ b/derp/derphttp/websocket.go
@@ -1,3 +1,6 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
 //go:build !js
 
 package derphttp


### PR DESCRIPTION
HTTP/2 doesn't support the 'Upgrade' header, which breaks the DERP exchange.