### PR TITLE
wgengine/netstack: switch to cubic congestion control

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -179,6 +179,11 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	if tcpipErr != nil {
 		return nil, fmt.Errorf("could not enable TCP SACK: %v", tcpipErr)
 	}
+	congestionOpt := tcpip.CongestionControlOption("cubic") // Reno is used by default
+	tcpipErr = ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &congestionOpt)
+	if tcpipErr != nil {
+		return nil, fmt.Errorf("could not set TCP congestion control: %v", tcpipErr)
+	}
 	linkEP := &protectedLinkEndpoint{Endpoint: channel.New(512, tstun.DefaultMTU(), "")}
 	if tcpipProblem := ipstack.CreateNIC(nicID, linkEP); tcpipProblem != nil {
 		return nil, fmt.Errorf("could not create netstack NIC: %v", tcpipProblem)


### PR DESCRIPTION
See https://github.com/tailscale/tailscale/pull/8106