### PR TITLE
wgengine/netstack: disable TCP SACK

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -179,11 +179,6 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 	if tcpipErr != nil {
 		return nil, fmt.Errorf("could not enable TCP SACK: %v", tcpipErr)
 	}
-	congestionOpt := tcpip.CongestionControlOption("cubic") // Reno is used by default
-	tcpipErr = ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &congestionOpt)
-	if tcpipErr != nil {
-		return nil, fmt.Errorf("could not set TCP congestion control: %v", tcpipErr)
-	}
 	linkEP := &protectedLinkEndpoint{Endpoint: channel.New(512, tstun.DefaultMTU(), "")}
 	if tcpipProblem := ipstack.CreateNIC(nicID, linkEP); tcpipProblem != nil {
 		return nil, fmt.Errorf("could not create netstack NIC: %v", tcpipProblem)

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -174,11 +174,13 @@ func Create(logf logger.Logf, tundev *tstun.Wrapper, e wgengine.Engine, mc *magi
 		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol, ipv6.NewProtocol},
 		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol, icmp.NewProtocol4, icmp.NewProtocol6},
 	})
-	sackEnabledOpt := tcpip.TCPSACKEnabled(true) // TCP SACK is disabled by default
+	// Issue: https://github.com/coder/coder/issues/7388
+	//
+	/*sackEnabledOpt := tcpip.TCPSACKEnabled(true) // TCP SACK is disabled by default
 	tcpipErr := ipstack.SetTransportProtocolOption(tcp.ProtocolNumber, &sackEnabledOpt)
 	if tcpipErr != nil {
 		return nil, fmt.Errorf("could not enable TCP SACK: %v", tcpipErr)
-	}
+	}*/
 	linkEP := &protectedLinkEndpoint{Endpoint: channel.New(512, tstun.DefaultMTU(), "")}
 	if tcpipProblem := ipstack.CreateNIC(nicID, linkEP); tcpipProblem != nil {
 		return nil, fmt.Errorf("could not create netstack NIC: %v", tcpipProblem)


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/7388

This PR disables TCP SACK (enabled by default) as in other experiments with MinRTO, MaxRTO tweaking didn't work. The idea is to keep this fix until the issue in gvisor is resolved. It also reverts https://github.com/coder/tailscale/pull/24.

I will follow-up with PR to coder/coder.