### PR TITLE
fix: use magicsock DERPHeaders in netcheck

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -443,6 +443,13 @@ func NewConn(opts Options) (*Conn, error) {
 		SkipExternalNetwork: inTest(),
 		PortMapper:          c.portMapper,
 		UseDNSCache:         true,
+		GetDERPHeaders: func() http.Header {
+			h := c.derpHeader.Load()
+			if h == nil {
+				return nil
+			}
+			return h.Clone()
+		},
 	}
 
 	c.ignoreSTUNPackets()


### PR DESCRIPTION
If the DERP server requires e.g. an auth header for the identity proxy then netcheck will always fail on the HTTP latency probes.