### PR TITLE
chore: avoid logging netcheck send errors if STUN is disabled

### DIFF
--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -28,6 +28,18 @@ type DERPMap struct {
 	OmitDefaultRegions bool `json:"omitDefaultRegions,omitempty"`
 }
 
+// HasSTUN returns true if there are any STUN servers in the DERPMap.
+func (m *DERPMap) HasSTUN() bool {
+	for _, r := range m.Regions {
+		for _, n := range r.Nodes {
+			if n.STUNPort > 0 && !n.STUNOnly {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // / RegionIDs returns the sorted region IDs.
 func (m *DERPMap) RegionIDs() []int {
 	ret := make([]int, 0, len(m.Regions))

--- a/tailcfg/derpmap.go
+++ b/tailcfg/derpmap.go
@@ -32,7 +32,7 @@ type DERPMap struct {
 func (m *DERPMap) HasSTUN() bool {
 	for _, r := range m.Regions {
 		for _, n := range r.Nodes {
-			if n.STUNPort > 0 && !n.STUNOnly {
+			if n.STUNPort >= 0 {
 				return true
 			}
 		}

--- a/tailcfg/tailcfg_test.go
+++ b/tailcfg/tailcfg_test.go
@@ -729,3 +729,121 @@ func TestCurrentCapabilityVersion(t *testing.T) {
 		t.Errorf("CurrentCapabilityVersion = %d; want %d", CurrentCapabilityVersion, max)
 	}
 }
+
+func TestDERPMapHasSTUN(t *testing.T) {
+	cases := []struct {
+		name    string
+		derpMap *DERPMap
+		want    bool
+	}{
+		{
+			name: "None",
+			derpMap: &DERPMap{
+				Regions: map[int]*DERPRegion{
+					1: {
+						RegionID: 1,
+						Nodes: []*DERPNode{
+							{
+								RegionID: 1,
+								Name:     "1a",
+								STUNPort: -1,
+							},
+						},
+					},
+					2: {
+						RegionID: 2,
+						Nodes: []*DERPNode{
+							{
+								RegionID: 2,
+								Name:     "2a",
+								STUNPort: -1,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "One",
+			derpMap: &DERPMap{
+				Regions: map[int]*DERPRegion{
+					1: {
+						RegionID: 1,
+						Nodes: []*DERPNode{
+							{
+								RegionID: 1,
+								Name:     "1a",
+								STUNPort: -1,
+							},
+						},
+					},
+					2: {
+						RegionID: 2,
+						Nodes: []*DERPNode{
+							{
+								RegionID: 2,
+								Name:     "2a",
+								STUNPort: -1,
+							},
+							{
+								RegionID: 2,
+								Name:     "2b",
+								STUNPort: 0, // default
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Some",
+			derpMap: &DERPMap{
+				Regions: map[int]*DERPRegion{
+					1: {
+						RegionID: 1,
+						Nodes: []*DERPNode{
+							{
+								RegionID: 1,
+								Name:     "1a",
+								STUNPort: -1,
+							},
+							{
+								RegionID: 1,
+								Name:     "1b",
+								STUNPort: 1234,
+							},
+						},
+					},
+					2: {
+						RegionID: 2,
+						Nodes: []*DERPNode{
+							{
+								RegionID: 2,
+								Name:     "2a",
+								STUNPort: -1,
+							},
+							{
+								RegionID: 2,
+								Name:     "2b",
+								STUNPort: 4321,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			got := c.derpMap.HasSTUN()
+			if got != c.want {
+				t.Errorf("got %v; want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -529,7 +529,7 @@ func (c *Conn) updateEndpoints(why string) {
 		c.muCond.Broadcast()
 	}()
 	c.dlogf("[v1] magicsock: starting endpoint update (%s)", why)
-	if c.noV4Send.Load() && runtime.GOOS != "js" {
+	if c.noV4Send.Load() && c.derpMapHasSTUNNodes() && runtime.GOOS != "js" {
 		c.mu.Lock()
 		closed := c.closed
 		c.mu.Unlock()
@@ -551,6 +551,13 @@ func (c *Conn) updateEndpoints(why string) {
 		c.logEndpointChange(endpoints)
 		c.epFunc(endpoints)
 	}
+}
+
+// c.mu must NOT be held.
+func (c *Conn) derpMapHasSTUNNodes() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.derpMap != nil && c.derpMap.HasSTUN()
 }
 
 // setEndpoints records the new endpoints, reporting whether they're changed.


### PR DESCRIPTION
This is a confusing log line to customers and happens when STUN is disabled. Also avoids the constant rebinding every 20 seconds which is pointless since we're not using the UDP socket at all in these situations.