### PR TITLE
fix: plan v4/v6 STUN probing based on relative index

### DIFF
--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -443,14 +443,14 @@ func TestPickDERPFallback(t *testing.T) {
 	c := newConn()
 	dm := &tailcfg.DERPMap{
 		Regions: map[int]*tailcfg.DERPRegion{
-			1: {},
-			2: {},
-			3: {},
-			4: {},
-			5: {},
-			6: {},
-			7: {},
-			8: {},
+			1: {Nodes: []*tailcfg.DERPNode{{}}},
+			2: {Nodes: []*tailcfg.DERPNode{{}}},
+			3: {Nodes: []*tailcfg.DERPNode{{}}},
+			4: {Nodes: []*tailcfg.DERPNode{{}}},
+			5: {Nodes: []*tailcfg.DERPNode{{}}},
+			6: {Nodes: []*tailcfg.DERPNode{{}}},
+			7: {Nodes: []*tailcfg.DERPNode{{}}},
+			8: {Nodes: []*tailcfg.DERPNode{{}}},
 		},
 	}
 	c.derpMap = dm


### PR DESCRIPTION
I'm still noticing some instability and my agent isn't probing STUN regions, and therefore failing netchecks.

I've noticed a bug in our planning, introduced with my previous change.  The choice of number of probes and v4 vs v6 for the probes was being computed based on the sorted speed index, rather than the relative index of only STUN regions.  So, if the first STUN region wasn't in the top 3 by speed, it could only get a single try and/or only v6 probes.  In pathological cases, you could end up with only v6 probes and no v4 probes.