### PR TITLE
feat: add magicsock opt to block direct endpoints

### DIFF
--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -431,6 +431,7 @@ func NewConn(opts Options) (*Conn, error) {
 	c.logf = opts.logf()
 	c.epFunc = opts.endpointsFunc()
 	c.derpActiveFunc = opts.derpActiveFunc()
+	c.blockEndpoints = opts.BlockEndpoints
 	c.idleFunc = opts.IdleFunc
 	c.testOnlyPacketListener = opts.TestOnlyPacketListener
 	c.noteRecvActivity = opts.NoteRecvActivity

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -548,7 +548,7 @@ func (c *Conn) updateEndpoints(why string) {
 		c.muCond.Broadcast()
 	}()
 	c.dlogf("[v1] magicsock: starting endpoint update (%s)", why)
-	if c.noV4Send.Load() && c.derpMapHasSTUNNodes() && runtime.GOOS != "js" {
+	if c.noV4Send.Load() && c.shouldRebindOnFailedNetcheckV4Send() && runtime.GOOS != "js" {
 		c.mu.Lock()
 		closed := c.closed
 		c.mu.Unlock()
@@ -573,10 +573,10 @@ func (c *Conn) updateEndpoints(why string) {
 }
 
 // c.mu must NOT be held.
-func (c *Conn) derpMapHasSTUNNodes() bool {
+func (c *Conn) shouldRebindOnFailedNetcheckV4Send() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.derpMap != nil && c.derpMap.HasSTUN()
+	return c.derpMap != nil && c.derpMap.HasSTUN() && !c.blockEndpoints
 }
 
 // setEndpoints records the new endpoints, reporting whether they're changed.

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -3112,14 +3112,13 @@ func TestBlockEndpointsDERPOK(t *testing.T) {
 func waitForNoEndpoints(t *testing.T, ms *Conn) {
 	t.Helper()
 	ok := false
-parentLoop:
 	for i := 0; i < 50; i++ {
 		time.Sleep(100 * time.Millisecond)
 		ms.mu.Lock()
-		for _, ep := range ms.lastEndpoints {
-			t.Errorf("endpoint %v was not blocked", ep.Addr)
+		if len(ms.lastEndpoints) != 0 {
+			t.Errorf("some endpoints were not blocked: %v", ms.lastEndpoints)
 			ms.mu.Unlock()
-			continue parentLoop
+			continue
 		}
 		ms.mu.Unlock()
 		ok = true

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -3013,7 +3013,7 @@ func TestBlockEndpoints(t *testing.T) {
 	defer ms.Close()
 
 	// Check that some endpoints exist. This should be the case as we should use
-	// interface addressess as endpoints instantly on startup, and we already
+	// interface addresses as endpoints instantly on startup, and we already
 	// have a DERP connection due to newMagicStackFunc.
 	ms.conn.mu.Lock()
 	haveEndpoint := false

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -3033,17 +3033,95 @@ func TestBlockEndpoints(t *testing.T) {
 	ms.conn.SetBlockEndpoints(true)
 
 	// Wait for endpoints to finish updating.
+	waitForNoEndpoints(t, ms.conn)
+}
+
+func TestBlockEndpointsDERPOK(t *testing.T) {
+	// This test is similar to TestBlockEndpoints, but it tests that we don't
+	// mess up DERP somehow.
+
+	mstun := &natlab.Machine{Name: "stun"}
+	m1 := &natlab.Machine{Name: "m1"}
+	m2 := &natlab.Machine{Name: "m2"}
+	inet := natlab.NewInternet()
+	sif := mstun.Attach("eth0", inet)
+	m1if := m1.Attach("eth0", inet)
+	m2if := m2.Attach("eth0", inet)
+
+	d := &devices{
+		m1:     m1,
+		m1IP:   m1if.V4(),
+		m2:     m2,
+		m2IP:   m2if.V4(),
+		stun:   mstun,
+		stunIP: sif.V4(),
+	}
+
+	logf, closeLogf := logger.LogfCloser(t.Logf)
+	defer closeLogf()
+
+	derpMap, cleanup := runDERPAndStun(t, t.Logf, localhostListener{}, netaddr.IPv4(127, 0, 0, 1))
+	defer cleanup()
+
+	ms1 := newMagicStack(t, logger.WithPrefix(logf, "conn1: "), d.m1, derpMap)
+	defer ms1.Close()
+	ms2 := newMagicStack(t, logger.WithPrefix(logf, "conn2: "), d.m2, derpMap)
+	defer ms2.Close()
+
+	cleanup = meshStacks(logf, nil, ms1, ms2)
+	defer cleanup()
+
+	m1IP := ms1.IP()
+	m2IP := ms2.IP()
+	logf("IPs: %s %s", m1IP, m2IP)
+
+	// SetBlockEndpoints is called later since it's incompatible with the test
+	// meshStacks implementations.
+	ms1.conn.SetBlockEndpoints(true)
+	ms2.conn.SetBlockEndpoints(true)
+	waitForNoEndpoints(t, ms1.conn)
+	waitForNoEndpoints(t, ms2.conn)
+
+	cleanup = newPinger(t, logf, ms1, ms2)
+	defer cleanup()
+
+	// Wait for both peers to know about each other.
+	for {
+		if s1 := ms1.Status(); len(s1.Peer) != 1 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if s2 := ms2.Status(); len(s2.Peer) != 1 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		break
+	}
+
+	cleanup = newPinger(t, t.Logf, ms1, ms2)
+	defer cleanup()
+
+	if len(ms1.conn.activeDerp) == 0 {
+		t.Errorf("unexpected DERP empty got: %v want: >0", len(ms1.conn.activeDerp))
+	}
+	if len(ms2.conn.activeDerp) == 0 {
+		t.Errorf("unexpected DERP empty got: %v want: >0", len(ms2.conn.activeDerp))
+	}
+}
+
+func waitForNoEndpoints(t *testing.T, ms *Conn) {
+	t.Helper()
 	ok := false
 parentLoop:
 	for i := 0; i < 50; i++ {
 		time.Sleep(100 * time.Millisecond)
-		ms.conn.mu.Lock()
-		for _, ep := range ms.conn.lastEndpoints {
+		ms.mu.Lock()
+		for _, ep := range ms.lastEndpoints {
 			t.Errorf("endpoint %v was not blocked", ep.Addr)
-			ms.conn.mu.Unlock()
+			ms.mu.Unlock()
 			continue parentLoop
 		}
-		ms.conn.mu.Unlock()
+		ms.mu.Unlock()
 		ok = true
 		break
 	}

--- a/wgengine/magicsock/magicsock_test.go
+++ b/wgengine/magicsock/magicsock_test.go
@@ -3127,4 +3127,5 @@ func waitForNoEndpoints(t *testing.T, ms *Conn) {
 	if !ok {
 		t.Fatal("endpoints were not blocked after 50 attempts")
 	}
+	t.Log("endpoints are blocked")
 }


### PR DESCRIPTION
Previously, BlockEndpoints was only implemented on Coder's side in the coordination protocol and by removing STUN servers from the DERP map. This had some gaps though... local endpoints gathered from interfaces on the PC would still be gathered and could still be sent to the other peer using disco call-me-maybe packets.

This disables storing (and therefore sending) any endpoints using a runtime-controllable setting on magicsock.

The UDP socket and portmapper are still created (for now) as removing them fully did not seem trivial without causing many bugs in the process.

Updates coder/coder#10791