### PR TITLE
feat: try IPv6 when dialing IPv4 loopback

### DIFF
--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -1000,6 +1000,22 @@ func (ns *Impl) forwardTCP(getClient func(...tcpip.SettableSocketOption) *gonet.
 	var stdDialer net.Dialer
 	server, err := stdDialer.DialContext(ctx, "tcp", dialAddrStr)
 	if err != nil {
+		// Coder: Retry with loopback IPv6 if the dial was for 127.0.0.1.
+		if dialAddr.Addr().Is4() && dialAddr.Addr().String() == "127.0.0.1" {
+			ipv6DialAddr := netip.AddrPortFrom(netip.IPv6Loopback(), dialAddr.Port())
+			server, err = stdDialer.DialContext(ctx, "tcp", ipv6DialAddr.String())
+			if err == nil {
+				dialAddr = ipv6DialAddr
+				dialAddrStr = ipv6DialAddr.String()
+				if debugNetstack() {
+					ns.logf("[coder] netstack: successful IPv4 loopback => IPv6 loopback hit: original = %s, new = %s", dialAddrStr, ipv6DialAddr.String())
+				}
+			} else {
+				ns.logf("netstack: could not connect to local server at %s (or %s)", dialAddrStr, ipv6DialAddr.String(), err)
+				return
+			}
+		}
+
 		ns.logf("netstack: could not connect to local server at %s: %v", dialAddr.String(), err)
 		return
 	}

--- a/wgengine/netstack/netstack.go
+++ b/wgengine/netstack/netstack.go
@@ -1005,19 +1005,19 @@ func (ns *Impl) forwardTCP(getClient func(...tcpip.SettableSocketOption) *gonet.
 			ipv6DialAddr := netip.AddrPortFrom(netip.IPv6Loopback(), dialAddr.Port())
 			server, err = stdDialer.DialContext(ctx, "tcp", ipv6DialAddr.String())
 			if err == nil {
+				if debugNetstack() {
+					ns.logf("[coder] netstack: successful IPv4 loopback => IPv6 loopback redirect: original = %s, new = %s", dialAddrStr, ipv6DialAddr.String())
+				}
 				dialAddr = ipv6DialAddr
 				dialAddrStr = ipv6DialAddr.String()
-				if debugNetstack() {
-					ns.logf("[coder] netstack: successful IPv4 loopback => IPv6 loopback hit: original = %s, new = %s", dialAddrStr, ipv6DialAddr.String())
-				}
 			} else {
 				ns.logf("netstack: could not connect to local server at %s (or %s)", dialAddrStr, ipv6DialAddr.String(), err)
 				return
 			}
+		} else {
+			ns.logf("netstack: could not connect to local server at %s: %v", dialAddr.String(), err)
+			return
 		}
-
-		ns.logf("netstack: could not connect to local server at %s: %v", dialAddr.String(), err)
-		return
 	}
 	defer server.Close()
 


### PR DESCRIPTION
If we fail to dial `127.0.0.1:x` over TCP when forwarding traffic, try `::1` as well.

This doesn't apply to UDP connections, which don't have "connections" and we therefore can't detect failures (unless we retried every single packet, which I think is a bad idea). The majority of users are only using TCP anyways so I think it's OK.

Relates to coder/coder#12906