### PR TITLE
fix: fix dropReason metrics labels

### DIFF
--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -326,15 +326,16 @@ func NewServer(privateKey key.NodePrivate, logf logger.Logf) *Server {
 	s.initMetacert()
 	s.packetsRecvDisco = s.packetsRecvByKind.Get("disco")
 	s.packetsRecvOther = s.packetsRecvByKind.Get("other")
-	s.packetsDroppedReasonCounters = []*expvar.Int{
-		s.packetsDroppedReason.Get("unknown_dest"),
-		s.packetsDroppedReason.Get("unknown_dest_on_fwd"),
-		s.packetsDroppedReason.Get("gone_disconnected"),
-		s.packetsDroppedReason.Get("gone_not_here"),
-		s.packetsDroppedReason.Get("queue_head"),
-		s.packetsDroppedReason.Get("queue_tail"),
-		s.packetsDroppedReason.Get("write_error"),
-	}
+
+	s.packetsDroppedReasonCounters = make([]*expvar.Int, 7)
+	s.packetsDroppedReasonCounters[dropReasonUnknownDest] = s.packetsDroppedReason.Get("unknown_dest")
+	s.packetsDroppedReasonCounters[dropReasonUnknownDestOnFwd] = s.packetsDroppedReason.Get("unknown_dest_on_fwd")
+	s.packetsDroppedReasonCounters[dropReasonGoneDisconnected] = s.packetsDroppedReason.Get("gone_disconnected")
+	s.packetsDroppedReasonCounters[dropReasonQueueHead] = s.packetsDroppedReason.Get("queue_head")
+	s.packetsDroppedReasonCounters[dropReasonQueueTail] = s.packetsDroppedReason.Get("queue_tail")
+	s.packetsDroppedReasonCounters[dropReasonWriteError] = s.packetsDroppedReason.Get("write_error")
+	s.packetsDroppedReasonCounters[dropReasonDupClient] = s.packetsDroppedReason.Get("dup_client")
+
 	s.packetsDroppedTypeDisco = s.packetsDroppedType.Get("disco")
 	s.packetsDroppedTypeOther = s.packetsDroppedType.Get("other")
 	return s


### PR DESCRIPTION
the `counter_packets_dropped_reason` metric is using incorrect labels, probably because a reason was dropped and a new one added to the end, causing the reasons between to be shifted out of alignment with their labels in the metrics.

The actual reasons are

```
const (
	dropReasonUnknownDest      dropReason = iota // unknown destination pubkey
	dropReasonUnknownDestOnFwd                   // unknown destination pubkey on a derp-forwarded packet
	dropReasonGoneDisconnected                   // destination tailscaled disconnected before we could send
	dropReasonQueueHead                          // destination queue is full, dropped packet at queue head
	dropReasonQueueTail                          // destination queue is full, dropped packet at queue tail
	dropReasonWriteError                         // OS write() failed
	dropReasonDupClient                          // the public key is connected 2+ times (active/active, fighting)
)
```

I noticed this while looking into DERP performance, since I was seeing a bunch of drops for `gone_not_here` which is not a valid reason in present version.