### PR TITLE
fix: increases DERP send queue length to 512 for increased throughput

### DIFF
--- a/derp/derp_server.go
+++ b/derp/derp_server.go
@@ -70,7 +70,13 @@ func init() {
 }
 
 const (
-	perClientSendQueueDepth = 32 // packets buffered for sending
+	// perClientSendQueueDepth is the number of packets to buffer for sending.
+	// CODER: We've modified this to 512, up from 32 in upstream Tailscale to improve DERP
+	// throughput.  32 is an understandable number for big, public DERP servers that Tailscale run,
+	// serving many thousands of connections, and where Tailscale is footing the bill.  In Coder's
+	// use case, we are serving hundreds to low thousands of users and the user's own company is
+	// paying the bills.  In testing, it increases DERP throughput up to 6x.
+	perClientSendQueueDepth = 512
 	writeTimeout            = 2 * time.Second
 )
 


### PR DESCRIPTION
Increases DERP send queue length.

Testing in AWS reveals that a major bottleneck to throughput via DERP is the DERP server itself dropping packets.  The queue is 32 packets by default, and even relatively modest speeds of ~50Mbit/s over a 10ms connection resulted in overflowing the queue and dropping packets.

Throughput tests in AWS show a marked increase in throughput with an increase to 512 packets.

![derp-queue-len-32-512](https://github.com/coder/tailscale/assets/5375600/0a2d8209-6f7a-4947-a7b4-94b8dc7c7536)
