### PR TITLE
chore: add missing netcheck report fields to netinfo

### DIFF
--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -805,7 +805,7 @@ func conciseOptBool(b opt.Bool, trueVal string) string {
 }
 
 // BasicallyEqual reports whether ni and ni2 are basically equal, ignoring
-// changes in DERP ServerLatency & RegionLatency
+// changes in DERP ServerLatency & RegionLatency.
 func (ni *NetInfo) BasicallyEqual(ni2 *NetInfo) bool {
 	if (ni == nil) != (ni2 == nil) {
 		return false

--- a/tailcfg/tailcfg.go
+++ b/tailcfg/tailcfg.go
@@ -733,7 +733,38 @@ type NetInfo struct {
 	// This should only be updated rarely, or when there's a
 	// material change, as any change here also gets uploaded to
 	// the control plane.
-	DERPLatency map[string]float64 `json:",omitempty"`
+	// Deprecated; use DERPLatencyV4 and DERPLatencyV6 instead.
+	DERPLatency   map[string]float64 `json:",omitempty"`
+	DERPLatencyV4 map[int]float64    `json:",omitempty"`
+	DERPLatencyV6 map[int]float64    `json:",omitempty"`
+
+	// a UDP STUN round trip completed
+	UDP bool `json:",omitempty"`
+
+	// an IPv6 STUN round trip completed
+	IPv6 bool `json:",omitempty"`
+
+	// an IPv4 STUN round trip completed
+	IPv4 bool `json:",omitempty"`
+
+	// an IPv6 packet was able to be sent
+	IPv6CanSend bool `json:",omitempty"`
+
+	// an IPv4 packet was able to be sent
+	IPv4CanSend bool `json:",omitempty"`
+
+	// an ICMPv4 round trip completed
+	ICMPv4 bool
+
+	// ip:port of global IPv4
+	GlobalV4 string
+
+	// [ip]:port of global IPv6
+	GlobalV6 string
+
+	// CaptivePortal is set when we think there's a captive portal that is
+	// intercepting HTTP traffic.
+	CaptivePortal opt.Bool
 
 	// Update BasicallyEqual when adding fields.
 }
@@ -774,7 +805,7 @@ func conciseOptBool(b opt.Bool, trueVal string) string {
 }
 
 // BasicallyEqual reports whether ni and ni2 are basically equal, ignoring
-// changes in DERP ServerLatency & RegionLatency.
+// changes in DERP ServerLatency & RegionLatency
 func (ni *NetInfo) BasicallyEqual(ni2 *NetInfo) bool {
 	if (ni == nil) != (ni2 == nil) {
 		return false
@@ -793,7 +824,16 @@ func (ni *NetInfo) BasicallyEqual(ni2 *NetInfo) bool {
 		ni.PMP == ni2.PMP &&
 		ni.PCP == ni2.PCP &&
 		ni.PreferredDERP == ni2.PreferredDERP &&
-		ni.LinkType == ni2.LinkType
+		ni.LinkType == ni2.LinkType &&
+		ni.UDP == ni2.UDP &&
+		ni.IPv6 == ni2.IPv6 &&
+		ni.IPv4 == ni2.IPv4 &&
+		ni.IPv6CanSend == ni2.IPv6CanSend &&
+		ni.IPv4CanSend == ni2.IPv4CanSend &&
+		ni.ICMPv4 == ni2.ICMPv4 &&
+		ni.GlobalV4 == ni2.GlobalV4 &&
+		ni.GlobalV6 == ni2.GlobalV6 &&
+		ni.CaptivePortal == ni2.CaptivePortal
 }
 
 // Equal reports whether h and h2 are equal.

--- a/tailcfg/tailcfg_clone.go
+++ b/tailcfg/tailcfg_clone.go
@@ -178,6 +178,18 @@ func (src *NetInfo) Clone() *NetInfo {
 			dst.DERPLatency[k] = v
 		}
 	}
+	if dst.DERPLatencyV4 != nil {
+		dst.DERPLatencyV4 = map[int]float64{}
+		for k, v := range src.DERPLatencyV4 {
+			dst.DERPLatencyV4[k] = v
+		}
+	}
+	if dst.DERPLatencyV6 != nil {
+		dst.DERPLatencyV6 = map[int]float64{}
+		for k, v := range src.DERPLatencyV6 {
+			dst.DERPLatencyV6[k] = v
+		}
+	}
 	return dst
 }
 
@@ -196,6 +208,17 @@ var _NetInfoCloneNeedsRegeneration = NetInfo(struct {
 	PreferredDERP         int
 	LinkType              string
 	DERPLatency           map[string]float64
+	DERPLatencyV4         map[int]float64
+	DERPLatencyV6         map[int]float64
+	UDP                   bool
+	IPv6                  bool
+	IPv4                  bool
+	IPv6CanSend           bool
+	IPv4CanSend           bool
+	ICMPv4                bool
+	GlobalV4              string
+	GlobalV6              string
+	CaptivePortal         opt.Bool
 }{})
 
 // Clone makes a deep copy of Login.

--- a/tailcfg/tailcfg_view.go
+++ b/tailcfg/tailcfg_view.go
@@ -410,7 +410,20 @@ func (v NetInfoView) PreferredDERP() int              { return v.ж.PreferredDER
 func (v NetInfoView) LinkType() string                { return v.ж.LinkType }
 
 func (v NetInfoView) DERPLatency() views.Map[string, float64] { return views.MapOf(v.ж.DERPLatency) }
-func (v NetInfoView) String() string                          { return v.ж.String() }
+
+func (v NetInfoView) DERPLatencyV4() views.Map[int, float64] { return views.MapOf(v.ж.DERPLatencyV4) }
+
+func (v NetInfoView) DERPLatencyV6() views.Map[int, float64] { return views.MapOf(v.ж.DERPLatencyV6) }
+func (v NetInfoView) UDP() bool                              { return v.ж.UDP }
+func (v NetInfoView) IPv6() bool                             { return v.ж.IPv6 }
+func (v NetInfoView) IPv4() bool                             { return v.ж.IPv4 }
+func (v NetInfoView) IPv6CanSend() bool                      { return v.ж.IPv6CanSend }
+func (v NetInfoView) IPv4CanSend() bool                      { return v.ж.IPv4CanSend }
+func (v NetInfoView) ICMPv4() bool                           { return v.ж.ICMPv4 }
+func (v NetInfoView) GlobalV4() string                       { return v.ж.GlobalV4 }
+func (v NetInfoView) GlobalV6() string                       { return v.ж.GlobalV6 }
+func (v NetInfoView) CaptivePortal() opt.Bool                { return v.ж.CaptivePortal }
+func (v NetInfoView) String() string                         { return v.ж.String() }
 
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _NetInfoViewNeedsRegeneration = NetInfo(struct {
@@ -427,6 +440,17 @@ var _NetInfoViewNeedsRegeneration = NetInfo(struct {
 	PreferredDERP         int
 	LinkType              string
 	DERPLatency           map[string]float64
+	DERPLatencyV4         map[int]float64
+	DERPLatencyV6         map[int]float64
+	UDP                   bool
+	IPv6                  bool
+	IPv4                  bool
+	IPv6CanSend           bool
+	IPv4CanSend           bool
+	ICMPv4                bool
+	GlobalV4              string
+	GlobalV6              string
+	CaptivePortal         opt.Bool
 }{})
 
 // View returns a readonly view of Login.

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -674,11 +674,20 @@ func (c *Conn) updateNetInfo(ctx context.Context) (*netcheck.Report, error) {
 		PMP:                   report.PMP,
 		PCP:                   report.PCP,
 		HavePortMap:           c.portMapper.HaveMapping(),
+		UDP:                   report.UDP,
+		IPv6:                  report.IPv6,
+		IPv4:                  report.IPv4,
+		IPv4CanSend:           report.IPv4CanSend,
+		ICMPv4:                report.ICMPv4,
+		GlobalV4:              report.GlobalV4,
+		GlobalV6:              report.GlobalV6,
 	}
 	for rid, d := range report.RegionV4Latency {
+		ni.DERPLatencyV4[rid] = d.Seconds()
 		ni.DERPLatency[fmt.Sprintf("%d-v4", rid)] = d.Seconds()
 	}
 	for rid, d := range report.RegionV6Latency {
+		ni.DERPLatencyV6[rid] = d.Seconds()
 		ni.DERPLatency[fmt.Sprintf("%d-v6", rid)] = d.Seconds()
 	}
 
@@ -687,6 +696,7 @@ func (c *Conn) updateNetInfo(ctx context.Context) (*netcheck.Report, error) {
 	ni.WorkingUDP.Set(report.UDP)
 	ni.WorkingICMPv4.Set(report.ICMPv4)
 	ni.PreferredDERP = report.PreferredDERP
+	ni.CaptivePortal = report.CaptivePortal
 
 	if ni.PreferredDERP == 0 {
 		// Perhaps UDP is blocked. Pick a deterministic but arbitrary


### PR DESCRIPTION
Tailscale chooses not to expose `netcheck.Report`, and instead opts to make `tailcfg.NetInfo` available via a callback, which is built using a `Report`. There's a few pieces of data in `Report` that we'd like to have for our network telemetry. 

Furthermore, `NetInfo` is not a proper subset of `Report`, so replacing it is non-trivial.
We should instead make `NetInfo` a superset of `Report`, as a means of future-proofing what we have access to from Tailscale in our network telemetry.