### PR TITLE
chore: make `noopManager` a no-op, even if a DNS config is supplied

### DIFF
--- a/net/dns/noop.go
+++ b/net/dns/noop.go
@@ -6,7 +6,7 @@ package dns
 type noopManager struct{}
 
 func (m noopManager) SetDNS(OSConfig) error  { return nil }
-func (m noopManager) SupportsSplitDNS() bool { return false }
+func (m noopManager) SupportsSplitDNS() bool { return true }
 func (m noopManager) Close() error           { return nil }
 func (m noopManager) GetBaseConfig() (OSConfig, error) {
 	return OSConfig{}, ErrGetBaseConfigNotSupported


### PR DESCRIPTION
Re: https://github.com/coder/coder/issues/14718

The Tailscale DNS manager that's used when you don't supply one to the wireguard engine (`noopManager`) returns false for whether it supports split DNS. If split DNS isn't supported, and a non-empty DNS config is supplied, the wireguard engine will try and get the base DNS config, which the no-op manager also doesn't support, and then logs an error, which fails a heap of `coder/coder` tests.

To address this, we can modify the default configurator to perform a no-op, even if a dns config is supplied.

We could also just set the DNS config conditionally (i.e. only for CoderVPN, or if a host has been supplied to the `tailnet.Conn`), but doing the plumbing for that seems not-great compared to just making this a no-op.

