### PR TITLE
chore: use coder DNS service address

### DIFF
--- a/net/dns/config.go
+++ b/net/dns/config.go
@@ -47,10 +47,7 @@ type Config struct {
 }
 
 func (c *Config) serviceIP() netip.Addr {
-	if c.OnlyIPv6 {
-		return tsaddr.TailscaleServiceIPv6()
-	}
-	return tsaddr.TailscaleServiceIP()
+	return tsaddr.CoderServiceIPv6()
 }
 
 // WriteToBufioWriter write a debug version of c for logs to w, omitting

--- a/net/dns/manager_test.go
+++ b/net/dns/manager_test.go
@@ -211,7 +211,7 @@ func TestManager(t *testing.T) {
 					"bar.tld.", "2.3.4.5"),
 			},
 			os: OSConfig{
-				Nameservers: mustIPs("100.100.100.100"),
+				Nameservers: mustIPs("fd60:627a:a42b::53"),
 			},
 			rs: resolver.Config{
 				Hosts: hosts(
@@ -297,7 +297,7 @@ func TestManager(t *testing.T) {
 					"bradfitz.ts.com.", "2.3.4.5"),
 			},
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 			},
 			rs: resolver.Config{
@@ -320,7 +320,7 @@ func TestManager(t *testing.T) {
 			},
 			split: true,
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 			},
 			rs: resolver.Config{
@@ -339,7 +339,7 @@ func TestManager(t *testing.T) {
 				SearchDomains:    fqdns("tailscale.com", "universe.tf"),
 			},
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 			},
 			rs: resolver.Config{
@@ -357,7 +357,7 @@ func TestManager(t *testing.T) {
 			},
 			split: true,
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 			},
 			rs: resolver.Config{
@@ -377,7 +377,7 @@ func TestManager(t *testing.T) {
 				SearchDomains: fqdns("coffee.shop"),
 			},
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf", "coffee.shop"),
 			},
 			rs: resolver.Config{
@@ -412,7 +412,7 @@ func TestManager(t *testing.T) {
 				SearchDomains: fqdns("coffee.shop"),
 			},
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf", "coffee.shop"),
 			},
 			rs: resolver.Config{
@@ -432,7 +432,7 @@ func TestManager(t *testing.T) {
 			},
 			split: true,
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 				MatchDomains:  fqdns("bigco.net", "corp.com"),
 			},
@@ -456,7 +456,7 @@ func TestManager(t *testing.T) {
 				SearchDomains: fqdns("coffee.shop"),
 			},
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf", "coffee.shop"),
 			},
 			rs: resolver.Config{
@@ -478,7 +478,7 @@ func TestManager(t *testing.T) {
 			},
 			split: true,
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 				MatchDomains:  fqdns("ts.com"),
 			},
@@ -503,7 +503,7 @@ func TestManager(t *testing.T) {
 				SearchDomains: fqdns("coffee.shop"),
 			},
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf", "coffee.shop"),
 			},
 			rs: resolver.Config{
@@ -529,7 +529,7 @@ func TestManager(t *testing.T) {
 			},
 			split: true,
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 				MatchDomains:  fqdns("corp.com", "ts.com"),
 			},
@@ -551,7 +551,7 @@ func TestManager(t *testing.T) {
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 			},
 			os: OSConfig{
-				Nameservers:   mustIPs("100.100.100.100"),
+				Nameservers:   mustIPs("fd60:627a:a42b::53"),
 				SearchDomains: fqdns("tailscale.com", "universe.tf"),
 			},
 			rs: resolver.Config{
@@ -579,7 +579,7 @@ func TestManager(t *testing.T) {
 				DefaultResolvers: mustRes("2a07:a8c0::c3:a884"),
 			},
 			os: OSConfig{
-				Nameservers: mustIPs("100.100.100.100"),
+				Nameservers: mustIPs("fd60:627a:a42b::53"),
 			},
 			rs: resolver.Config{
 				Routes: upstreams(".", "2a07:a8c0::c3:a884"),
@@ -591,10 +591,34 @@ func TestManager(t *testing.T) {
 				DefaultResolvers: mustRes("https://dns.nextdns.io/c3a884"),
 			},
 			os: OSConfig{
-				Nameservers: mustIPs("100.100.100.100"),
+				Nameservers: mustIPs("fd60:627a:a42b::53"),
 			},
 			rs: resolver.Config{
 				Routes: upstreams(".", "https://dns.nextdns.io/c3a884"),
+			},
+		},
+		{
+			name: "coder",
+			in: Config{
+				OnlyIPv6: true,
+				Routes: map[dnsname.FQDN][]*dnstype.Resolver{
+					"coder.": nil,
+				},
+				Hosts: hosts(
+					"agent.myws.me.coder.", "fd60:627a:a42c::53",
+				),
+			},
+			os: OSConfig{
+				Nameservers: mustIPs("fd60:627a:a42b::53"),
+			},
+			rs: resolver.Config{
+				Routes: upstreams(
+					".", "",
+				),
+				Hosts: hosts(
+					"agent.myws.me.coder.", "fd60:627a:a42c::53",
+				),
+				LocalDomains: fqdns("coder."),
 			},
 		},
 	}

--- a/net/tsaddr/tsaddr.go
+++ b/net/tsaddr/tsaddr.go
@@ -35,13 +35,14 @@ func CGNATRange() netip.Prefix {
 }
 
 var (
-	cgnatRange   oncePrefix
-	ulaRange     oncePrefix
-	tsUlaRange   oncePrefix
-	tsViaRange   oncePrefix
-	ula4To6Range oncePrefix
-	ulaEph6Range oncePrefix
-	serviceIPv6  oncePrefix
+	cgnatRange       oncePrefix
+	ulaRange         oncePrefix
+	tsUlaRange       oncePrefix
+	tsViaRange       oncePrefix
+	ula4To6Range     oncePrefix
+	ulaEph6Range     oncePrefix
+	serviceIPv6      oncePrefix
+	coderServiceIPv6 oncePrefix
 )
 
 // TailscaleServiceIP returns the IPv4 listen address of services
@@ -61,9 +62,15 @@ func TailscaleServiceIPv6() netip.Addr {
 	return serviceIPv6.v.Addr()
 }
 
+func CoderServiceIPv6() netip.Addr {
+	coderServiceIPv6.Do(func() { mustPrefix(&coderServiceIPv6.v, CoderServiceIPv6String+"/128") })
+	return coderServiceIPv6.v.Addr()
+}
+
 const (
 	TailscaleServiceIPString   = "100.100.100.100"
 	TailscaleServiceIPv6String = "fd7a:115c:a1e0::53"
+	CoderServiceIPv6String     = "fd60:627a:a42b::53"
 )
 
 // IsTailscaleIP reports whether ip is an IP address in a range that

--- a/net/tsaddr/tsaddr_test.go
+++ b/net/tsaddr/tsaddr_test.go
@@ -53,6 +53,14 @@ func TestTailscaleServiceIPv6(t *testing.T) {
 	}
 }
 
+func TestCoderServiceIPv6(t *testing.T) {
+	got := CoderServiceIPv6().String()
+	want := "fd60:627a:a42b::53"
+	if got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}
+
 func TestChromeOSVMRange(t *testing.T) {
 	if got, want := ChromeOSVMRange().String(), "100.115.92.0/23"; got != want {
 		t.Errorf("got %q; want %q", got, want)


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/14718

This enables the Tailscale built-in DNS nameserver (`Resolver`) to listen on the pre-determined Coder DNS address, `[fd60:627a:a42b::53]:53`. 

Note that there's currently a hardcoded check in the DNS manager that ignores the hosts on `dns.Config` unless `goos= "windows"`. This means the platform specific part of CoderVPN won't get the specific host mappings, only the address of the Tailscale nameserver. If we need to modify the hosts file on Windows, we'll need to change that (answer pending dean's return) .

For example, this `in: dns.Config` produces the following OS config, and Resolver config:
```
in: Config{
	OnlyIPv6: true,
	Routes: map[dnsname.FQDN][]*dnstype.Resolver{
		"coder.": nil,
	},
	Hosts: hosts(
		"agent.myws.me.coder.", "fd60:627a:a42c::53",
	),
},
os: OSConfig{
	Nameservers: mustIPs("fd60:627a:a42b::53"),
},
rs: resolver.Config{
	Routes: upstreams(
		".", "",
	),
	Hosts: hosts(
		"agent.myws.me.coder.", "fd60:627a:a42c::53",
	),
	LocalDomains: fqdns("coder."),
},
```