### PR TITLE
fix: avoid interference with Tailscale on Windows

### DIFF
--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -9,9 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -20,7 +18,6 @@ import (
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
-	"tailscale.com/atomicfile"
 	"tailscale.com/envknob"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/dnsname"
@@ -154,30 +151,36 @@ func setTailscaleHosts(prevHostsFile []byte, hosts []*HostEntry) ([]byte, error)
 
 // setHosts sets the hosts file to contain the given host entries.
 func (m *windowsManager) setHosts(hosts []*HostEntry) error {
-	systemDir, err := windows.GetSystemDirectory()
-	if err != nil {
-		return err
-	}
-	hostsFile := filepath.Join(systemDir, "drivers", "etc", "hosts")
-	b, err := os.ReadFile(hostsFile)
-	if err != nil {
-		return err
-	}
-	outB, err := setTailscaleHosts(b, hosts)
-	if err != nil {
-		return err
-	}
-	const fileMode = 0 // ignored on windows.
+	// Coder: we don't use the hosts file, but this code will still try to write
+	// it and interfere with real Tailscale.
+	return nil
 
-	// This can fail spuriously with an access denied error, so retry it a
-	// few times.
-	for i := 0; i < 5; i++ {
-		if err = atomicfile.WriteFile(hostsFile, outB, fileMode); err == nil {
-			return nil
+	/*
+		systemDir, err := windows.GetSystemDirectory()
+		if err != nil {
+			return err
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return err
+		hostsFile := filepath.Join(systemDir, "drivers", "etc", "hosts")
+		b, err := os.ReadFile(hostsFile)
+		if err != nil {
+			return err
+		}
+		outB, err := setTailscaleHosts(b, hosts)
+		if err != nil {
+			return err
+		}
+		const fileMode = 0 // ignored on windows.
+
+		// This can fail spuriously with an access denied error, so retry it a
+		// few times.
+		for i := 0; i < 5; i++ {
+			if err = atomicfile.WriteFile(hostsFile, outB, fileMode); err == nil {
+				return nil
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		return err
+	*/
 }
 
 // setPrimaryDNS sets the given resolvers and domains as the Tailscale

--- a/net/dns/manager_windows.go
+++ b/net/dns/manager_windows.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -18,6 +20,7 @@ import (
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
+	"tailscale.com/atomicfile"
 	"tailscale.com/envknob"
 	"tailscale.com/types/logger"
 	"tailscale.com/util/dnsname"
@@ -107,11 +110,11 @@ func setTailscaleHosts(prevHostsFile []byte, hosts []*HostEntry) ([]byte, error)
 	b := bytes.ReplaceAll(prevHostsFile, []byte("\r\n"), []byte("\n"))
 	sc := bufio.NewScanner(bytes.NewReader(b))
 	const (
-		header = "# TailscaleHostsSectionStart"
-		footer = "# TailscaleHostsSectionEnd"
+		header = "# CoderHostsSectionStart"
+		footer = "# CoderHostsSectionEnd"
 	)
 	var comments = []string{
-		"# This section contains MagicDNS entries for Tailscale.",
+		"# This section contains DNS entries for Coder workspaces.",
 		"# Do not edit this section manually.",
 	}
 	var out bytes.Buffer
@@ -151,36 +154,30 @@ func setTailscaleHosts(prevHostsFile []byte, hosts []*HostEntry) ([]byte, error)
 
 // setHosts sets the hosts file to contain the given host entries.
 func (m *windowsManager) setHosts(hosts []*HostEntry) error {
-	// Coder: we don't use the hosts file, but this code will still try to write
-	// it and interfere with real Tailscale.
-	return nil
-
-	/*
-		systemDir, err := windows.GetSystemDirectory()
-		if err != nil {
-			return err
-		}
-		hostsFile := filepath.Join(systemDir, "drivers", "etc", "hosts")
-		b, err := os.ReadFile(hostsFile)
-		if err != nil {
-			return err
-		}
-		outB, err := setTailscaleHosts(b, hosts)
-		if err != nil {
-			return err
-		}
-		const fileMode = 0 // ignored on windows.
-
-		// This can fail spuriously with an access denied error, so retry it a
-		// few times.
-		for i := 0; i < 5; i++ {
-			if err = atomicfile.WriteFile(hostsFile, outB, fileMode); err == nil {
-				return nil
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
+	systemDir, err := windows.GetSystemDirectory()
+	if err != nil {
 		return err
-	*/
+	}
+	hostsFile := filepath.Join(systemDir, "drivers", "etc", "hosts")
+	b, err := os.ReadFile(hostsFile)
+	if err != nil {
+		return err
+	}
+	outB, err := setTailscaleHosts(b, hosts)
+	if err != nil {
+		return err
+	}
+	const fileMode = 0 // ignored on windows.
+
+	// This can fail spuriously with an access denied error, so retry it a
+	// few times.
+	for i := 0; i < 5; i++ {
+		if err = atomicfile.WriteFile(hostsFile, outB, fileMode); err == nil {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return err
 }
 
 // setPrimaryDNS sets the given resolvers and domains as the Tailscale

--- a/net/dns/nrpt_windows.go
+++ b/net/dns/nrpt_windows.go
@@ -29,7 +29,9 @@ const (
 	// This is the legacy rule ID that previous versions used when we supported
 	// only a single rule. Now that we support multiple rules are required, we
 	// generate their GUIDs and store them under the Tailscale registry key.
-	nrptSingleRuleID = `{5abe529b-675b-4486-8459-25a634dacc23}`
+	//
+	// Coder: this value was changed to avoid messing with Tailscale.
+	nrptSingleRuleID = `{09040707-2be9-491d-9d7b-62a454e774d2}`
 
 	// This is the name of the registry value we use to save Rule IDs under
 	// the Tailscale registry key.

--- a/util/winutil/winutil_windows.go
+++ b/util/winutil/winutil_windows.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	regBase       = `SOFTWARE\Tailscale IPN`
-	regPolicyBase = `SOFTWARE\Policies\Tailscale`
+	regBase       = `SOFTWARE\Coder VPN`
+	regPolicyBase = `SOFTWARE\Policies\Coder`
 )
 
 // ErrNoShell is returned when the shell process is not found.


### PR DESCRIPTION
Tailscale uses the hosts file as they register the tailnet as a search domain, and they want to overcome the ~3s multicast DNS timeout that often happens on home networks when there's a query for a suffixless hostname.

We currently don't use search domains, but we'd probably want to in the future, so instead of removing the hosts file code from coder/tailscale I changed the section identifiers we use.

Also updates some registry paths to avoid conflicting with Tailscale.

Closes https://github.com/coder/coder-desktop-windows/issues/15