### PR TITLE
fix: stop selecting direct connections with too-small MTU

### DIFF
--- a/disco/disco.go
+++ b/disco/disco.go
@@ -54,7 +54,10 @@ const v1 = byte(1)
 
 // paddedPayloadLen is the desired length we want to pad Ping and Pong payloads
 // to so that they are the maximum size of a Wireguard packet we would
-// subsequently send.
+// subsequently send. This ensures that any UDP paths we discover will actually
+// support the packet sizes the net stack will send over those paths. Any peers
+// behind a small-MTU link will have to depend on DERP.
+// c.f. https://github.com/coder/coder/issues/15523
 // Our inner IP packets can be up to 1280 bytes, with the Wireguard header of
 // 30 bytes, that is 1310. The final 2 is the inner payload header's type and version.
 const paddedPayloadLen = 1310 - len(Magic) - keyLen - NonceLen - box.Overhead - 2

--- a/disco/disco_test.go
+++ b/disco/disco_test.go
@@ -25,7 +25,7 @@ func TestMarshalAndParse(t *testing.T) {
 			m: &Ping{
 				TxID: [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 			},
-			want: "01 00 01 02 03 04 05 06 07 08 09 0a 0b 0c",
+			want: "01 01 01 02 03 04 05 06 07 08 09 0a 0b 0c",
 		},
 		{
 			name: "ping_with_nodekey_src",
@@ -33,7 +33,7 @@ func TestMarshalAndParse(t *testing.T) {
 				TxID:    [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 				NodeKey: key.NodePublicFromRaw32(mem.B([]byte{1: 1, 2: 2, 30: 30, 31: 31})),
 			},
-			want: "01 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 01 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 1e 1f",
+			want: "01 01 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 01 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 1e 1f",
 		},
 		{
 			name: "pong",
@@ -41,7 +41,7 @@ func TestMarshalAndParse(t *testing.T) {
 				TxID: [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 				Src:  mustIPPort("2.3.4.5:1234"),
 			},
-			want: "02 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 00 00 00 00 00 00 00 00 00 ff ff 02 03 04 05 04 d2",
+			want: "02 01 01 02 03 04 05 06 07 08 09 0a 0b 0c 00 00 00 00 00 00 00 00 00 00 ff ff 02 03 04 05 04 d2",
 		},
 		{
 			name: "pongv6",
@@ -49,7 +49,7 @@ func TestMarshalAndParse(t *testing.T) {
 				TxID: [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 				Src:  mustIPPort("[fed0::12]:6666"),
 			},
-			want: "02 00 01 02 03 04 05 06 07 08 09 0a 0b 0c fe d0 00 00 00 00 00 00 00 00 00 00 00 00 00 12 1a 0a",
+			want: "02 01 01 02 03 04 05 06 07 08 09 0a 0b 0c fe d0 00 00 00 00 00 00 00 00 00 00 00 00 00 12 1a 0a",
 		},
 		{
 			name: "call_me_maybe",
@@ -77,8 +77,8 @@ func TestMarshalAndParse(t *testing.T) {
 			}
 
 			gotHex := fmt.Sprintf("% x", got)
-			if gotHex != tt.want {
-				t.Fatalf("wrong marshal\n got: %s\nwant: %s\n", gotHex, tt.want)
+			if !strings.HasPrefix(gotHex, tt.want) {
+				t.Fatalf("wrong marshal\n got: %s\nwant prefix: %s\n", gotHex, tt.want)
 			}
 
 			back, err := Parse([]byte(got))
@@ -87,6 +87,69 @@ func TestMarshalAndParse(t *testing.T) {
 			}
 			if !reflect.DeepEqual(back, tt.m) {
 				t.Errorf("message in %+v doesn't match Parse back result %+v", tt.m, back)
+			}
+		})
+	}
+}
+
+func TestParsePingPongV0(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		m       Message
+	}{
+		{
+			name: "ping",
+			m: &Ping{
+				TxID: [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+			},
+			payload: []byte{0x01, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
+		},
+		{
+			name: "ping_with_nodekey_src",
+			m: &Ping{
+				TxID:    [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+				NodeKey: key.NodePublicFromRaw32(mem.B([]byte{1: 1, 2: 2, 30: 30, 31: 31})),
+			},
+			payload: []byte{
+				0x01, 0x00,
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+				0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1e, 0x1f},
+		},
+		{
+			name: "pong",
+			m: &Pong{
+				TxID: [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+				Src:  mustIPPort("2.3.4.5:1234"),
+			},
+			payload: []byte{
+				0x02, 0x00,
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x02, 0x03, 0x04, 0x05,
+				0x04, 0xd2},
+		},
+		{
+			name: "pongv6",
+			m: &Pong{
+				TxID: [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+				Src:  mustIPPort("[fed0::12]:6666"),
+			},
+			payload: []byte{
+				0x02, 0x00,
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+				0xfe, 0xd0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12,
+				0x1a, 0x0a},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			back, err := Parse(tt.payload)
+			if err != nil {
+				t.Fatalf("parse back: %v", err)
+			}
+			if !reflect.DeepEqual(back, tt.m) {
+				t.Errorf("message in %+v doesn't match Parse result %+v", tt.m, back)
 			}
 		})
 	}

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2377,7 +2377,12 @@ func (c *Conn) bindSocket(ruc *RebindingUDPConn, network string, curPortFate cur
 			continue
 		}
 		trySetSocketBuffer(pconn, c.logf)
-		trySetPathMTUDiscover(pconn, c.logf, network)
+		// CODER: https://github.com/coder/coder/issues/15523
+		// Attempt to tell the OS not to fragment packets over this interface. We pad disco Ping and Pong packets to the
+		// size of the direct UDP packets that get sent for direct connections. Thus, any interfaces or paths that
+		// cannot fully support direct connections due to MTU limitations will not be selected. If no direct paths meet
+		// the MTU requirements for a peer, we will fall back to DERP for that peer.
+		tryPreventFragmentation(pconn, c.logf, network)
 		// Success.
 		if debugBindSocket() {
 			c.logf("magicsock: bindSocket: successfully listened %v port %d", network, port)

--- a/wgengine/magicsock/magicsock.go
+++ b/wgengine/magicsock/magicsock.go
@@ -2377,6 +2377,7 @@ func (c *Conn) bindSocket(ruc *RebindingUDPConn, network string, curPortFate cur
 			continue
 		}
 		trySetSocketBuffer(pconn, c.logf)
+		trySetPathMTUDiscover(pconn, c.logf, network)
 		// Success.
 		if debugBindSocket() {
 			c.logf("magicsock: bindSocket: successfully listened %v port %d", network, port)

--- a/wgengine/magicsock/magicsock_darwin.go
+++ b/wgengine/magicsock/magicsock_darwin.go
@@ -1,0 +1,6 @@
+package magicsock
+
+func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network string) {
+	// TODO: implement
+	logf("magicsock: failed to set Path MTU Discover: not implemented")
+}

--- a/wgengine/magicsock/magicsock_darwin.go
+++ b/wgengine/magicsock/magicsock_darwin.go
@@ -1,6 +1,36 @@
 package magicsock
 
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+	"tailscale.com/types/logger"
+	"tailscale.com/types/nettype"
+)
+
 func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network string) {
-	// TODO: implement
-	logf("magicsock: failed to set Path MTU Discover: not implemented")
+	if c, ok := pconn.(*net.UDPConn); ok {
+		s, err := c.SyscallConn()
+		if err != nil {
+			logf("magicsock: failed to set Path MTU Discover: get syscall conn: %v", err)
+		}
+		level := unix.IPPROTO_IP
+		option := unix.IP_MTU_DISCOVER
+		if network == "udp6" {
+			level = unix.IPPROTO_IPV6
+			option = unix.IPV6_MTU_DISCOVER
+		}
+		err = s.Control(func(fd uintptr) {
+			err := unix.SetsockoptInt(int(fd), level, option, unix.IP_PMTUDISC_DO)
+			if err != nil {
+				logf("magicsock: failed to set Path MTU Discover: SetsockoptInt failed: %v", err)
+			}
+		})
+		if err != nil {
+			logf("magicsock: failed to set Path MTU Discover: control connection: %v", err)
+		}
+		logf("magicsock: successfully set Path MTU Discover on %s", pconn.LocalAddr().String())
+		return
+	}
+	logf("magicsock: failed to set Path MTU Discover: not a UDPConn")
 }

--- a/wgengine/magicsock/magicsock_darwin.go
+++ b/wgengine/magicsock/magicsock_darwin.go
@@ -15,13 +15,13 @@ func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network s
 			logf("magicsock: failed to set Path MTU Discover: get syscall conn: %v", err)
 		}
 		level := unix.IPPROTO_IP
-		option := unix.IP_MTU_DISCOVER
+		option := unix.IP_DONTFRAG
 		if network == "udp6" {
 			level = unix.IPPROTO_IPV6
-			option = unix.IPV6_MTU_DISCOVER
+			option = unix.IPV6_DONTFRAG
 		}
 		err = s.Control(func(fd uintptr) {
-			err := unix.SetsockoptInt(int(fd), level, option, unix.IP_PMTUDISC_DO)
+			err := unix.SetsockoptInt(int(fd), level, option, 1)
 			if err != nil {
 				logf("magicsock: failed to set Path MTU Discover: SetsockoptInt failed: %v", err)
 			}

--- a/wgengine/magicsock/magicsock_linux.go
+++ b/wgengine/magicsock/magicsock_linux.go
@@ -405,11 +405,11 @@ func init() {
 	controlMessageSize = unix.CmsgSpace(2)
 }
 
-func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network string) {
+func tryPreventFragmentation(pconn nettype.PacketConn, logf logger.Logf, network string) {
 	if c, ok := pconn.(*net.UDPConn); ok {
 		s, err := c.SyscallConn()
 		if err != nil {
-			logf("magicsock: failed to set Path MTU Discover: get syscall conn: %v", err)
+			logf("magicsock: dontfrag: failed to get syscall conn: %v", err)
 		}
 		level := unix.IPPROTO_IP
 		option := unix.IP_MTU_DISCOVER
@@ -420,14 +420,14 @@ func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network s
 		err = s.Control(func(fd uintptr) {
 			err := unix.SetsockoptInt(int(fd), level, option, unix.IP_PMTUDISC_DO)
 			if err != nil {
-				logf("magicsock: failed to set Path MTU Discover: SetsockoptInt failed: %v", err)
+				logf("magicsock: dontfrag: SetsockoptInt failed: %v", err)
 			}
 		})
 		if err != nil {
-			logf("magicsock: failed to set Path MTU Discover: control connection: %v", err)
+			logf("magicsock: dontfrag: control connection failed: %v", err)
 		}
-		logf("magicsock: successfully set Path MTU Discover on %s", pconn.LocalAddr().String())
+		logf("magicsock: dontfrag: success on %s", pconn.LocalAddr().String())
 		return
 	}
-	logf("magicsock: failed to set Path MTU Discover: not a UDPConn")
+	logf("magicsock: dontfrag: failed because it was not a UDPConn")
 }

--- a/wgengine/magicsock/magicsock_linux.go
+++ b/wgengine/magicsock/magicsock_linux.go
@@ -404,3 +404,8 @@ func init() {
 	// message. These contain a single uint16 of data.
 	controlMessageSize = unix.CmsgSpace(2)
 }
+
+func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network string) {
+	// TODO: implement
+	logf("magicsock: failed to set Path MTU Discover: not implemented")
+}

--- a/wgengine/magicsock/magicsock_linux.go
+++ b/wgengine/magicsock/magicsock_linux.go
@@ -406,6 +406,28 @@ func init() {
 }
 
 func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network string) {
-	// TODO: implement
-	logf("magicsock: failed to set Path MTU Discover: not implemented")
+	if c, ok := pconn.(*net.UDPConn); ok {
+		s, err := c.SyscallConn()
+		if err != nil {
+			logf("magicsock: failed to set Path MTU Discover: get syscall conn: %v", err)
+		}
+		level := unix.IPPROTO_IP
+		option := unix.IP_MTU_DISCOVER
+		if network == "udp6" {
+			level = unix.IPPROTO_IPV6
+			option = unix.IPV6_MTU_DISCOVER
+		}
+		err = s.Control(func(fd uintptr) {
+			err := unix.SetsockoptInt(int(fd), level, option, unix.IP_PMTUDISC_DO)
+			if err != nil {
+				logf("magicsock: failed to set Path MTU Discover: SetsockoptInt failed: %v", err)
+			}
+		})
+		if err != nil {
+			logf("magicsock: failed to set Path MTU Discover: control connection: %v", err)
+		}
+		logf("magicsock: successfully set Path MTU Discover on %s", pconn.LocalAddr().String())
+		return
+	}
+	logf("magicsock: failed to set Path MTU Discover: not a UDPConn")
 }

--- a/wgengine/magicsock/magicsock_windows.go
+++ b/wgengine/magicsock/magicsock_windows.go
@@ -22,7 +22,6 @@ const (
 )
 
 func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network string) {
-	logf("setting Path MTU Discover on %s", pconn.LocalAddr().String())
 	if c, ok := pconn.(*net.UDPConn); ok {
 		s, err := c.SyscallConn()
 		if err != nil {
@@ -41,7 +40,7 @@ func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network s
 		if err != nil {
 			logf("magicsock: failed to set Path MTU Discover: control connection: %v", err)
 		}
-		logf("sucessfully set Path MTU Discover on %s", pconn.LocalAddr().String())
+		logf("magicsock: successfully set Path MTU Discover on %s", pconn.LocalAddr().String())
 		return
 	}
 	logf("magicsock: failed to set Path MTU Discover: not a UDPConn")

--- a/wgengine/magicsock/magicsock_windows.go
+++ b/wgengine/magicsock/magicsock_windows.go
@@ -1,0 +1,48 @@
+package magicsock
+
+import (
+	"net"
+
+	"golang.org/x/sys/windows"
+	"tailscale.com/types/logger"
+	"tailscale.com/types/nettype"
+)
+
+// https://github.com/tpn/winsdk-10/blob/9b69fd26ac0c7d0b83d378dba01080e93349c2ed/Include/10.0.16299.0/shared/ws2ipdef.h
+const (
+	IP_MTU_DISCOVER = 71 // IPV6_MTU_DISCOVER has the same value, which is nice.
+)
+
+const (
+	IP_PMTUDISC_NOT_SET = iota
+	IP_PMTUDISC_DO
+	IP_PMTUDISC_DONT
+	IP_PMTUDISC_PROBE
+	IP_PMTUDISC_MAX
+)
+
+func trySetPathMTUDiscover(pconn nettype.PacketConn, logf logger.Logf, network string) {
+	logf("setting Path MTU Discover on %s", pconn.LocalAddr().String())
+	if c, ok := pconn.(*net.UDPConn); ok {
+		s, err := c.SyscallConn()
+		if err != nil {
+			logf("magicsock: failed to set Path MTU Discover: get syscall conn: %v", err)
+		}
+		level := windows.IPPROTO_IP
+		if network == "udp6" {
+			level = windows.IPPROTO_IPV6
+		}
+		err = s.Control(func(fd uintptr) {
+			err := windows.SetsockoptInt(windows.Handle(fd), level, IP_MTU_DISCOVER, IP_PMTUDISC_DO)
+			if err != nil {
+				logf("magicsock: failed to set Path MTU Discover: SetsockoptInt failed: %v", err)
+			}
+		})
+		if err != nil {
+			logf("magicsock: failed to set Path MTU Discover: control connection: %v", err)
+		}
+		logf("sucessfully set Path MTU Discover on %s", pconn.LocalAddr().String())
+		return
+	}
+	logf("magicsock: failed to set Path MTU Discover: not a UDPConn")
+}


### PR DESCRIPTION
related to: https://github.com/coder/coder/issues/15523

This PR:

1. pads disco Ping and Pong packets so they are the largest size we expect to get from the inner tunnel IP stack, which has a hardcoded MTU of 1280 (minimum to support IPv6).
2. configures Windows, macOS, and Linux _not_ to fragment UDP packets sent out over the magicsock.

The end result is that Disco Ping and Pong packets are not directly exchanged over paths with too-small MTU, and thus, those endpoints are not chosen for direct connections. (Alternate direct paths with bigger MTU may be chosen, or we may fall back to DERP.)