### PR TITLE
derp/derphttp: honor DERPNode.DERPPort in proxied CONNECT dial

### DIFF
--- a/derp/derphttp/derphttp_client.go
+++ b/derp/derphttp/derphttp_client.go
@@ -990,7 +990,12 @@ func (c *Client) dialNodeUsingProxy(ctx context.Context, n *tailcfg.DERPNode, pr
 		}
 	}()
 
-	target := net.JoinHostPort(n.HostName, "443")
+	// Keep port selection in sync with dialNode.
+	port := "443"
+	if n.DERPPort != 0 {
+		port = fmt.Sprint(n.DERPPort)
+	}
+	target := net.JoinHostPort(n.HostName, port)
 
 	var authHeader string
 	if v, err := tshttpproxy.GetAuthHeader(pu); err != nil {


### PR DESCRIPTION
Cherry-pick of tailscale/tailscale#19752 (fixes tailscale/tailscale#19748) onto coder's fork.

When `derphttp.Client` routes a DERP connection through an HTTPS forward proxy (`HTTPS_PROXY`), the CONNECT request always targets port 443, even when the DERP map specifies a custom `DERPPort`.

The non-proxy path, `dialNode`, [derp/derphttp/derphttp_client.go#L909-L913](https://github.com/coder/tailscale/blob/286a5336e6a9648fcfdf685740c1bbfde9cdc211/derp/derphttp/derphttp_client.go#L909-L913), correctly honors `n.DERPPort`:

```go
port := "443"
if n.DERPPort != 0 {
    port = fmt.Sprint(n.DERPPort)
}
```

The proxy path, `dialNodeUsingProxy`, [same file L993](https://github.com/coder/tailscale/blob/286a5336e6a9648fcfdf685740c1bbfde9cdc211/derp/derphttp/derphttp_client.go#L993), hardcodes `"443"` and never consults `n.DERPPort`:

```go
target := net.JoinHostPort(n.HostName, "443")
```

A custom DERP server on a non-443 port is therefore unreachable through `HTTPS_PROXY`: the CONNECT line is sent to `host:443`, the proxy faithfully tunnels to whatever sits on :443 at that hostname/IP, and TLS either fails on cert validation (if a different service runs on :443) or talks to the wrong service.

This PR mirrors `dialNode`'s port selection in `dialNodeUsingProxy`. The end-to-end test from the upstream PR doesn't port cleanly (this fork lacks `feature.HookProxyFromEnvironment`, renamed/narrowed types) and the unit-test variant was dropped on the upstream PR (commit bb8b711bec), so this PR is fix-only.